### PR TITLE
[fix] run command example typo in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ You can also run each sample directly from the command line.
 ```
 * Run the individual samples by name. For example: 
 ```
-    $ node PaymentTransactions\[CodeSampleName]
+    $ node PaymentTransactions/[CodeSampleName]
 ```
 e.g.
 ```
-    $ node PaymentTransactions\authorize-credit-card.js
+    $ node PaymentTransactions/authorize-credit-card.js
 ```


### PR DESCRIPTION
Line 26 and 30 was having "\" but it should have "/" instead